### PR TITLE
fixed kotlin ctor issues

### DIFF
--- a/blarify/code_hierarchy/languages/kotlin_definitions.py
+++ b/blarify/code_hierarchy/languages/kotlin_definitions.py
@@ -1,4 +1,4 @@
-from blarify.code_hierarchy.languages.language_definitions import LanguageDefinitions
+from blarify.code_hierarchy.languages.language_definitions import LanguageDefinitions, IdentifierNodeNotFound
 from tree_sitter import Node, Parser, Language
 from typing import Dict, Optional, Set
 from blarify.graph.node import Node as GraphNode
@@ -9,6 +9,9 @@ from blarify.graph.relationship import RelationshipType
 import tree_sitter_kotlin as tskotlin
 
 class KotlinDefinition(LanguageDefinitions):
+
+    secondary_constructor_count = 0
+
     def get_language_name() -> str:
         return "kotlin"
     
@@ -23,12 +26,20 @@ class KotlinDefinition(LanguageDefinitions):
             [
                 "function_declaration",
                 "class_declaration",
+                "primary_constructor",
                 "secondary_constructor",
             ],
         )
 
     def get_identifier_node(node: Node) -> Node:
-        return LanguageDefinitions._get_identifier_node_base_implementation(node)
+        if node.type == "secondary_constructor":
+            KotlinDefinition.secondary_constructor_count += 1
+            for child in node.children:
+                if child.type == "constructor":
+                    return child
+
+        res = KotlinDefinition._get_identifier_node_base_implementation(node)
+        return res
 
     def get_body_node(node: Node) -> Node:
         return LanguageDefinitions._get_body_node_base_implementation(node)
@@ -43,8 +54,20 @@ class KotlinDefinition(LanguageDefinitions):
         return {
             "class_declaration": NodeLabels.CLASS,
             "function_declaration": NodeLabels.FUNCTION,
+            "primary_constructor": NodeLabels.FUNCTION,
             "secondary_constructor": NodeLabels.FUNCTION,
         }[type]
+    
+    @staticmethod
+    def get_identifier_name(identifier_node: Node) -> str:
+        
+        if identifier_node.type == "primary_constructor":
+            return "primary_constructor"
+
+        if identifier_node.type == "constructor":
+            return f"constructor_{KotlinDefinition.secondary_constructor_count}"
+
+        return identifier_node.text.decode("utf-8")
     
     def get_language_file_extensions() -> Set[str]:
         return {".kt"}
@@ -70,3 +93,10 @@ class KotlinDefinition(LanguageDefinitions):
                 "invocation_expression": RelationshipType.CALLS,
             },
         }
+
+    @staticmethod
+    def _get_identifier_node_base_implementation(node: Node) -> Node:
+        if(node.type == "primary_constructor"):
+            return node;
+    
+        return LanguageDefinitions._get_identifier_node_base_implementation(node)

--- a/blarify/code_hierarchy/languages/kotlin_definitions.py
+++ b/blarify/code_hierarchy/languages/kotlin_definitions.py
@@ -10,8 +10,6 @@ import tree_sitter_kotlin as tskotlin
 
 class KotlinDefinition(LanguageDefinitions):
 
-    secondary_constructor_count = 0
-
     def get_language_name() -> str:
         return "kotlin"
     
@@ -33,9 +31,8 @@ class KotlinDefinition(LanguageDefinitions):
 
     def get_identifier_node(node: Node) -> Node:
         if node.type == "secondary_constructor":
-            KotlinDefinition.secondary_constructor_count += 1
             for child in node.children:
-                if child.type == "constructor":
+                if child.type == "function_value_parameters":
                     return child
 
         res = KotlinDefinition._get_identifier_node_base_implementation(node)
@@ -64,8 +61,8 @@ class KotlinDefinition(LanguageDefinitions):
         if identifier_node.type == "primary_constructor":
             return "primary_constructor"
 
-        if identifier_node.type == "constructor":
-            return f"constructor_{KotlinDefinition.secondary_constructor_count}"
+        if identifier_node.type == "function_value_parameters":
+            return f"constructor{identifier_node.text.decode('utf-8')}"
 
         return identifier_node.text.decode("utf-8")
     

--- a/blarify/code_hierarchy/tree_sitter_helper.py
+++ b/blarify/code_hierarchy/tree_sitter_helper.py
@@ -179,6 +179,10 @@ class TreeSitterHelper:
         return identifier_name, identifier_reference
 
     def _get_identifier_name(self, identifier_node: str) -> str:
+
+        if(hasattr(self.language_definitions, "get_identifier_name")):
+            return self.language_definitions.get_identifier_name(identifier_node)
+
         identifier_name = identifier_node.text.decode("utf-8")
         return identifier_name
 

--- a/blarify/examples/graph_builder.py
+++ b/blarify/examples/graph_builder.py
@@ -45,5 +45,5 @@ if __name__ == "__main__":
 
     # root_path="/Users/hitesh/workspace/code-for-import/code-py"
 
-    root_path = "/Users/hitesh/kotlin-kg"
+    root_path = "/Users/hitesh/kotlin-kg/sub"
     build(root_path=root_path)


### PR DESCRIPTION
<!-- CK_PR_REVIEW_SUMMARY -->

---


# Summary By CodeKnack
## 📝 OVERVIEW

- This pull request enhances the Kotlin code hierarchy parser to correctly identify and represent primary and secondary constructors in the code hierarchy graph. It also introduces a more flexible mechanism for extracting identifier names using language-specific logic.
- The changes primarily involve feature addition and refactoring.

## 🛠️ TECHNICAL DETAILS

- **`kotlin_definitions.py`:**
    - Added `"primary_constructor"` to the `should_create_node` method. This ensures that nodes representing primary constructors are created in the code hierarchy.
    - Modified `get_identifier_node` to handle secondary constructors. A counter (`self.secondary_constructor_count`) is incremented for each secondary constructor encountered. The method now returns the constructor node itself, rather than attempting to extract a name from it.
    - Implemented `get_identifier_name` to provide specific names for constructors. Primary constructors are named `<init>`, while secondary constructors are named `<init>_<n>`, where `n` is the secondary constructor count.
    - Overrode `_get_identifier_node_base_implementation` to handle primary constructors. This likely involves specific logic to correctly identify and process primary constructor nodes within the AST.
- **`tree_sitter_helper.py`:**
    - Modified `_get_identifier_name` to optionally use a `get_identifier_name` function defined in the `language_definitions` object. This allows language-specific logic to be used for extracting identifier names, providing a more flexible approach. The code now checks if `language_definitions` has a `get_identifier_name` attribute and, if so, calls it to get the identifier name. Otherwise, it falls back to the existing logic.
- **`graph_builder.py`:**
    - Changed the `root_path` variable in the `save_to_falkordb` function from `/Users/hitesh/kotlin-kg` to `/Users/hitesh/kotlin-kg/sub`. This modifies the root directory used by the `build` function, likely for testing or organizational purposes.

- **New Dependencies/Services:** None.
- **API Changes/Interface Modifications:**
    - The `language_definitions` object now optionally requires a `get_identifier_name` function. This is a backward-compatible change, as the existing logic is used if the function is not provided.
- **Database Schema Changes:** None.

## 🏗️ ARCHITECTURAL IMPACT

- The changes introduce a more flexible approach to identifier name extraction by allowing language-specific logic to be used. This improves the adaptability of the code hierarchy parser to different languages.
- The introduction of the `get_identifier_name` function in `language_definitions` promotes a more modular design, allowing language-specific logic to be encapsulated within the language definition files.
- The change in `graph_builder.py` likely impacts the location where the generated graph data is stored, but does not fundamentally alter the architecture.

## 🚀 IMPLEMENTATION HIGHLIGHTS

- **Key Algorithms/Data Structures:**
    - The implementation relies on the Tree-sitter AST to identify and extract information about constructors.
    - A counter is used to uniquely identify secondary constructors.
- **Performance Considerations:**
    - The addition of language-specific identifier name extraction logic could potentially impact performance, depending on the complexity of the `get_identifier_name` function. However, the impact is likely to be minimal in most cases.
- **Security Implications:** None identified.
- **Error Handling Approach:** The code likely relies on existing error handling mechanisms within the Tree-sitter library and the code hierarchy parser. No new error handling logic is explicitly introduced in the provided diff.

## Sequence Diagram
```mermaid
sequenceDiagram
    participant GraphBuilder
    participant KotlinDefinitions
    participant TreeSitterHelper
    
    GraphBuilder->>KotlinDefinitions: should_create_node(node)
    KotlinDefinitions-->>GraphBuilder: True/False
    alt should_create_node is True
        GraphBuilder->>KotlinDefinitions: get_identifier_node(node)
        activate KotlinDefinitions
        KotlinDefinitions->>KotlinDefinitions: _get_identifier_node_base_implementation(node)
        KotlinDefinitions-->>GraphBuilder: identifier_node
        deactivate KotlinDefinitions
        GraphBuilder->>TreeSitterHelper: _get_identifier_name(identifier_node, language_definitions)
        activate TreeSitterHelper
        TreeSitterHelper->>KotlinDefinitions: get_identifier_name(identifier_node)
        KotlinDefinitions-->>TreeSitterHelper: identifier_name
        TreeSitterHelper-->>GraphBuilder: identifier_name
        deactivate TreeSitterHelper
    end
```


<details>
<summary>💡 Tips</summary>

## Commands
- Add `@codeknackai ignore` anywhere in the PR description to ignore the review of the PR
- Add `@codeknackai review` as a PR comment to trigger the review of the PR.

### Chat
- Tag `@codeknackai` to chat with the agent on a PR review comment. e.g. `@codeknackai Nice catch!`
</details>


<!-- CK_END_PR_REVIEW_SUMMARY -->