### PR TITLE
increased the timeout

### DIFF
--- a/blarify/code_references/lsp_helper.py
+++ b/blarify/code_references/lsp_helper.py
@@ -124,7 +124,7 @@ class LspQueryHelper:
         return [Reference(reference) for reference in references]
 
     def _request_references_with_exponential_backoff(self, node, lsp):
-        timeout = 10
+        timeout = 45
         for attempt in range(1, 3):
             try:
                 references = lsp.request_references(
@@ -266,7 +266,7 @@ class LspQueryHelper:
         return definitions[0]["uri"]
 
     def _request_definition_with_exponential_backoff(self, reference: Reference, lsp, extension):
-        timeout = 10
+        timeout = 45
         for attempt in range(1, 3):
             try:
                 definitions = lsp.request_definition(


### PR DESCRIPTION
<!-- CK_PR_REVIEW_SUMMARY -->

---


# Summary By CodeKnack
## 📝 OVERVIEW
The pull request increases the timeout value for Language Server Protocol (LSP) requests to prevent timeout errors when retrieving code references and definitions. This is a bug fix addressing potential performance issues with the LSP server.

## 🔑 KEY CHANGES
- Increased the timeout for LSP reference requests from 10 seconds to 45 seconds.
- Increased the timeout for LSP definition requests from 10 seconds to 45 seconds.

## Sequence Diagram
```mermaid
sequenceDiagram
    participant LSPHelper
    participant LSPServer

    LSPHelper->>LSPServer: Request References (timeout=45s)
    activate LSPServer
    LSPServer-->>LSPHelper: References Response
    deactivate LSPServer

    LSPHelper->>LSPServer: Request Definition (timeout=45s)
    activate LSPServer
    LSPServer-->>LSPHelper: Definition Response
    deactivate LSPServer
```


<details>
<summary>💡 Tips</summary>

## Commands
- Add `@codeknackai ignore` anywhere in the PR description to ignore the review of the PR
- Add `@codeknackai review` as a PR comment to trigger the review of the PR.

### Chat
- Tag `@codeknackai` to chat with the agent on a PR review comment. e.g. `@codeknackai Nice catch!`
</details>


<!-- CK_END_PR_REVIEW_SUMMARY -->